### PR TITLE
Fix issue#16

### DIFF
--- a/contracts/src/main/kotlin/net/ntworld/mergeRequest/Pipeline.kt
+++ b/contracts/src/main/kotlin/net/ntworld/mergeRequest/Pipeline.kt
@@ -11,9 +11,9 @@ interface Pipeline {
 
     val url: String
 
-    val createdAt: DateTime
+    val createdAt: DateTime?
 
-    val updatedAt: DateTime
+    val updatedAt: DateTime?
 
     companion object
 }

--- a/merge-request-integration/src/main/kotlin/net/ntworld/mergeRequestIntegration/internal/PipelineImpl.kt
+++ b/merge-request-integration/src/main/kotlin/net/ntworld/mergeRequestIntegration/internal/PipelineImpl.kt
@@ -10,6 +10,6 @@ data class PipelineImpl(
     override val ref: String,
     override val status: PipelineStatus,
     override val url: String,
-    override val createdAt: DateTime,
-    override val updatedAt: DateTime
+    override val createdAt: DateTime?,
+    override val updatedAt: DateTime?
 ) : Pipeline

--- a/merge-request-integration/src/main/kotlin/net/ntworld/mergeRequestIntegration/provider/gitlab/model/PipelineModel.kt
+++ b/merge-request-integration/src/main/kotlin/net/ntworld/mergeRequestIntegration/provider/gitlab/model/PipelineModel.kt
@@ -14,10 +14,10 @@ data class PipelineModel(
     val status: String,
 
     @SerialName("created_at")
-    val createdAt: String,
+    val createdAt: String? = null,
 
     @SerialName("updated_at")
-    val updatedAt: String,
+    val updatedAt: String? = null,
 
     @SerialName("web_url")
     val webUrl: String


### PR DESCRIPTION
- add pipelines backward compatibility with GitLab version < 12.4

As @vdsirotkin mentioned at [issue](https://github.com/nhat-phan/merge-request-integration/issues/16) sometimes pipeline status is unavailable.

According to GitLab REST API docs, fields created_at and updated_at are not supported in versions lower than 12.4

Fix tested with GitLab 12.3