### PR TITLE
Update to directly use git to calculate changes for diffs

### DIFF
--- a/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/infrastructure/service/RepositoryFileService.kt
+++ b/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/infrastructure/service/RepositoryFileService.kt
@@ -1,12 +1,13 @@
 package net.ntworld.mergeRequestIntegrationIde.infrastructure.service
 
 import com.intellij.openapi.vcs.changes.Change
+import net.ntworld.mergeRequest.MergeRequestInfo
 import net.ntworld.mergeRequest.ProviderData
 import javax.swing.Icon
 
 interface RepositoryFileService {
 
-    fun findChanges(providerData: ProviderData, hashes: List<String>): List<Change>
+    fun findChanges(providerData: ProviderData, mergeRequestInfo: MergeRequestInfo, hashes: List<String>): List<Change>
 
     fun findIcon(providerData: ProviderData, path: String) : Icon
 

--- a/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/infrastructure/service/repositoryFile/CachedRepositoryFile.kt
+++ b/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/infrastructure/service/repositoryFile/CachedRepositoryFile.kt
@@ -2,6 +2,7 @@ package net.ntworld.mergeRequestIntegrationIde.infrastructure.service.repository
 
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.vcs.changes.Change
+import net.ntworld.mergeRequest.MergeRequestInfo
 import net.ntworld.mergeRequest.ProviderData
 import net.ntworld.mergeRequest.api.Cache
 import net.ntworld.mergeRequestIntegrationIde.infrastructure.service.RepositoryFileService
@@ -13,11 +14,11 @@ class CachedRepositoryFile(
 ) : RepositoryFileDecorator(service) {
     private val myLogger = Logger.getInstance(this.javaClass)
 
-    override fun findChanges(providerData: ProviderData, hashes: List<String>): List<Change> {
+    override fun findChanges(providerData: ProviderData, mergeRequestInfo: MergeRequestInfo, hashes: List<String>): List<Change> {
         val key = "${providerData.id}:${hashes.joinToString(",")}"
         return cache.getOrRun(key) {
             myLogger.info("Cache $key not found")
-            val result = super.findChanges(providerData, hashes)
+            val result = super.findChanges(providerData, mergeRequestInfo, hashes)
 
             cache.set(key, result, FIND_CHANGES_TTL)
             result

--- a/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/infrastructure/service/repositoryFile/RepositoryFileDecorator.kt
+++ b/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/infrastructure/service/repositoryFile/RepositoryFileDecorator.kt
@@ -1,6 +1,7 @@
 package net.ntworld.mergeRequestIntegrationIde.infrastructure.service.repositoryFile
 
 import com.intellij.openapi.vcs.changes.Change
+import net.ntworld.mergeRequest.MergeRequestInfo
 import net.ntworld.mergeRequest.ProviderData
 import net.ntworld.mergeRequestIntegrationIde.infrastructure.service.RepositoryFileService
 import javax.swing.Icon
@@ -9,8 +10,8 @@ open class RepositoryFileDecorator(
     private val service: RepositoryFileService
 ) : RepositoryFileService {
 
-    override fun findChanges(providerData: ProviderData, hashes: List<String>): List<Change> {
-        return service.findChanges(providerData, hashes)
+    override fun findChanges(providerData: ProviderData, mergeRequestInfo: MergeRequestInfo, hashes: List<String>): List<Change> {
+        return service.findChanges(providerData, mergeRequestInfo, hashes)
     }
 
     override fun findIcon(providerData: ProviderData, path: String): Icon {

--- a/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/task/GetCommitsTask.kt
+++ b/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/task/GetCommitsTask.kt
@@ -5,16 +5,18 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.progress.impl.BackgroundableProcessIndicator
 import net.ntworld.mergeRequest.Commit
-import net.ntworld.mergeRequest.MergeRequestInfo
+import net.ntworld.mergeRequest.MergeRequest
 import net.ntworld.mergeRequest.ProviderData
 import net.ntworld.mergeRequest.query.GetCommitsQuery
 import net.ntworld.mergeRequestIntegration.make
+import net.ntworld.mergeRequestIntegration.provider.gitlab.request.GitlabFindMRRequest
+import net.ntworld.mergeRequestIntegration.provider.gitlab.transformer.GitlabMRTransformer
 import net.ntworld.mergeRequestIntegrationIde.infrastructure.ProjectServiceProvider
 
 class GetCommitsTask(
     private val projectServiceProvider: ProjectServiceProvider,
     private val providerData: ProviderData,
-    private val mergeRequestInfo: MergeRequestInfo,
+    private val mergeRequest: MergeRequest,
     private val listener: Listener
 ) : Task.Backgroundable(projectServiceProvider.project, "Fetching commit data...", false) {
     fun start() {
@@ -31,11 +33,11 @@ class GetCommitsTask(
             listener.taskStarted()
             val result = projectServiceProvider.infrastructure.queryBus() process GetCommitsQuery.make(
                 providerId = providerData.id,
-                mergeRequestId = mergeRequestInfo.id
+                mergeRequestId = mergeRequest.id
             )
-            listener.dataReceived(mergeRequestInfo, result.commits)
+            listener.dataReceived(mergeRequest, result.commits)
             projectServiceProvider.reviewContextManager.updateCommits(
-                providerData.id, mergeRequestInfo.id, result.commits
+                providerData.id, mergeRequest.id, result.commits
             )
             listener.taskEnded()
         } catch (exception: Exception) {
@@ -50,7 +52,7 @@ class GetCommitsTask(
 
         fun taskStarted() {}
 
-        fun dataReceived(mergeRequestInfo: MergeRequestInfo, commits: List<Commit>)
+        fun dataReceived(mergeRequest: MergeRequest, commits: List<Commit>)
 
         fun taskEnded() {}
     }

--- a/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/ui/mergeRequest/MergeRequestDetails.kt
+++ b/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/ui/mergeRequest/MergeRequestDetails.kt
@@ -78,6 +78,8 @@ class MergeRequestDetails(
             ApplicationManager.getApplication().invokeLater {
                 setMergeRequest(mergeRequest)
             }
+
+            GetCommitsTask(projectServiceProvider, providerData, mergeRequest, myGetCommitsListener).start()
         }
     }
     private val myGetPipelinesListener = object : GetPipelinesTask.Listener {
@@ -102,12 +104,12 @@ class MergeRequestDetails(
             myCommitsTab.clear()
         }
 
-        override fun dataReceived(mergeRequestInfo: MergeRequestInfo, commits: List<Commit>) {
+        override fun dataReceived(mergeRequest: MergeRequest, commits: List<Commit>) {
             ApplicationManager.getApplication().invokeLater {
                 myToolbars.forEach {
-                    it.setCommits(mergeRequestInfo, commits)
+                    it.setCommits(mergeRequest, commits)
                 }
-                myCommitsTab.setCommits(providerData, mergeRequestInfo, commits)
+                myCommitsTab.setCommits(providerData, mergeRequest, commits)
                 if (commits.isEmpty()) {
                     myCommitsTabInfo.text = "Commits"
                 } else {
@@ -190,7 +192,6 @@ class MergeRequestDetails(
         }
         FindMergeRequestTask(projectServiceProvider, providerData, mergeRequestInfo, myFindMRListener).start()
         GetPipelinesTask(projectServiceProvider, providerData, mergeRequestInfo, myGetPipelinesListener).start()
-        GetCommitsTask(projectServiceProvider, providerData, mergeRequestInfo, myGetCommitsListener).start()
         if (providerData.hasApprovalFeature) {
             FindApprovalTask(projectServiceProvider, providerData, mergeRequestInfo, myFindApprovalListener).start()
         }

--- a/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/ui/mergeRequest/tab/commit/CommitChanges.kt
+++ b/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/ui/mergeRequest/tab/commit/CommitChanges.kt
@@ -76,7 +76,7 @@ class CommitChanges(private val projectServiceProvider: ProjectServiceProvider) 
         myMergeRequestInfo = mergeRequestInfo
         thread {
             myTree.isVisible = false
-            val changes = projectServiceProvider.repositoryFile.findChanges(providerData, commits.map { it.id })
+            val changes = projectServiceProvider.repositoryFile.findChanges(providerData, mergeRequestInfo, commits.map { it.id })
             projectServiceProvider.reviewContextManager.updateChanges(providerData.id, mergeRequestInfo.id, changes)
             projectServiceProvider.reviewContextManager.updateReviewingChanges(providerData.id, mergeRequestInfo.id, changes)
             ApplicationManager.getApplication().invokeLater {
@@ -95,7 +95,7 @@ class CommitChanges(private val projectServiceProvider: ProjectServiceProvider) 
         myMergeRequestInfo = mergeRequestInfo
         thread {
             myTree.isVisible = false
-            val partialChanges = projectServiceProvider.repositoryFile.findChanges(providerData, selectedCommits.map { it.id })
+            val partialChanges = projectServiceProvider.repositoryFile.findChanges(providerData, mergeRequestInfo, selectedCommits.map { it.id })
             projectServiceProvider.reviewContextManager.updateReviewingChanges(
                 providerData.id, mergeRequestInfo.id, partialChanges
             )

--- a/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/ui/service/DisplayChangesService.kt
+++ b/merge-request-integration-core/src/main/kotlin/net/ntworld/mergeRequestIntegrationIde/ui/service/DisplayChangesService.kt
@@ -10,6 +10,7 @@ import com.intellij.vcs.log.Hash
 import com.intellij.vcs.log.impl.VcsLogContentUtil
 import com.intellij.vcs.log.impl.VcsLogManager
 import com.intellij.vcs.log.util.VcsLogUtil
+import git4idea.changes.GitChangeUtils
 import git4idea.repo.GitRepository
 import net.ntworld.mergeRequest.Commit
 import net.ntworld.mergeRequest.MergeRequest
@@ -112,27 +113,11 @@ object DisplayChangesService {
         log: VcsLogManager,
         commits: List<Commit>
     ) {
-        // TODO: Reduce repetition
-        val details = VcsLogUtil.getDetails(
-            log.dataManager.getLogProvider(repository.root),
-            repository.root,
-            commits.map { it.id }
-        )
-        if (details.isEmpty()) {
-            return
-        }
+        val changes = GitChangeUtils.getDiff(repository, mergeRequest.targetBranch, mergeRequest.sourceBranch, true);
 
-        if (details.size == 1) {
-            return displayChanges(
-                applicationServiceProvider, ideaProject,
-                providerData, mergeRequest, details.first().changes.toList()
-            )
+        if (changes != null) {
+            displayChanges(applicationServiceProvider, ideaProject, providerData, mergeRequest, changes.toList())
         }
-
-        val changes = VcsLogUtil.collectChanges(details) {
-            it.changes
-        }
-        displayChanges(applicationServiceProvider, ideaProject, providerData, mergeRequest, changes)
     }
 
     private fun displayChanges(


### PR DESCRIPTION
Fixes #72 

I'm not primarily a Java/Kotlin developer so this took some time to figure out. There's might be some mistakes and there might well be a better way of doing this.

I know that these changes won't be compatible with the feature that allows you to select which commits to review from the MR. This will now only allow you to compare the source and target branch.

From what I can gather the plugin currently calculates the changes by combining the changeset of the commits in the MR. 

For example, if the two branches are updated simultaneously and merged together, you will end up seeing the changes from the target branch/merge commit in the diff.

This isn't the same as a `git diff`.

The changes I've made make it the exact equivalent of running `git diff <target>..<source>` (because it actually runs that command).

Given that it now runs the commit command, it means it's obviously only compatible with Git but I don't think that's an issue as other parts of the plugin are tailored to git only.

In order to re-implement the "select commits to compare" feature, you will likely need to use the `merge-base` command [as explained here](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-emgitdiffemltoptionsgtltcommitgtltcommitgt--ltpathgt82308203) or find another way of doing what the MR does.